### PR TITLE
1.5.1 (#1145)

### DIFF
--- a/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
@@ -30,7 +30,10 @@ namespace Xamarin.Essentials
             if (!Platform.HasOSVersion(13, 0))
                 return AppTheme.Unspecified;
 
-            return Platform.GetCurrentViewController().TraitCollection.UserInterfaceStyle switch
+            var uiStyle = Platform.GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
+                UITraitCollection.CurrentTraitCollection.UserInterfaceStyle;
+
+            return uiStyle switch
             {
                 UIUserInterfaceStyle.Light => AppTheme.Light,
                 UIUserInterfaceStyle.Dark => AppTheme.Dark,

--- a/Xamarin.Essentials/Launcher/Launcher.shared.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.shared.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Essentials
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
 
-            return PlatformCanOpenAsync(uri);
+            return PlatformTryOpenAsync(uri);
         }
     }
 

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -224,15 +224,22 @@ namespace Xamarin.Essentials
 
         public partial class LocationAlways : BasePlatformPermission
         {
-            public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-                new (string, bool)[]
+            public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+            {
+                get
                 {
+                    var permissions = new List<(string, bool)>();
 #if __ANDROID_29__
-                    (Manifest.Permission.AccessBackgroundLocation, true),
+                    if (Platform.HasApiLevelQ)
+                        permissions.Add((Manifest.Permission.AccessBackgroundLocation, true));
 #endif
-                    (Manifest.Permission.AccessCoarseLocation, true),
-                    (Manifest.Permission.AccessFineLocation, true)
-                };
+
+                    permissions.Add((Manifest.Permission.AccessCoarseLocation, true));
+                    permissions.Add((Manifest.Permission.AccessFineLocation, true));
+
+                    return permissions.ToArray();
+                }
+            }
         }
 
         public partial class Maps : BasePlatformPermission

--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Essentials
 
         public abstract partial class BasePlatformPermission : BasePermission
         {
-            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; }
+            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; } = () => Array.Empty<string>();
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -173,6 +173,13 @@ namespace Xamarin.Essentials
             false;
 #endif
 
+        internal static bool HasApiLevelQ =>
+#if __ANDROID_29__
+            HasApiLevel(BuildVersionCodes.Q);
+#else
+            false;
+#endif
+
         internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
             (int)Build.VERSION.SdkInt >= (int)versionCode;
 

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -51,6 +51,7 @@
     <None Include="..\Assets\xamarin.essentials_128x128.png" PackagePath="icon.png" Pack="true" />
     <None Include="..\nugetreadme.txt" PackagePath="readme.txt" Pack="true" />
     <PackageReference Include="mdoc" Version="5.7.4.10" PrivateAssets="All" />
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />
   </ItemGroup>

--- a/docs/en/Xamarin.Essentials/PlacemarkExtensions.xml
+++ b/docs/en/Xamarin.Essentials/PlacemarkExtensions.xml
@@ -11,7 +11,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Extensions for the palcemark.</summary>
+    <summary>Extensions for the placemark.</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>


### PR DESCRIPTION
* Implement vertical accuracy in GeoLocation API (#1103)

* Location: add property 'VerticalAccuracy' (#1099)

* vertical accuracy is only available in Android API level 26 and above (#1099)

* update Samples app to show vertical accuracy on GeolocationPage

* add missing documentation bits for Location.VerticalAccuracy

* .gitattributes: get better diff context for C# code (#1115)

* Location.VerticalAccuracy: add runtime check for Android version (#1099) (#1116)

* the compile-time check is not enough
* it crashed on old Android versions (<8.0)

* GH-1102 Fix launcher on older devices (#1120)

* Update Launcher.ios.tvos.cs

* OpenUrlAsync was introduced in iOS 10 not 12

https://docs.microsoft.com/en-us/dotnet/api/uikit.uiapplication.openurlasync?view=xamarin-ios-sdk-12

* Fix trailing whitespace

* Really? fix whitespace

* Really! Fix whitespace

* Fixes #1129 - set empty required declarations on UWP (#1133)

* Fixes #1129 - set empty required declarations on UWP

* Update Permissions.uwp.cs

* Update Xamarin.Essentials.csproj (#1136)

* GH-1142 AccessBackgroundLocation only when compile & running Q (#1143)

* AccessBackgroundLocation only when compile & running Q

* put if compile check around permission

* GH-1121 If VC is null use TraitCollection (#1144)

* Fixes #1123 (#1126)

* Update PlacemarkExtensions.xml (#1132)

Co-authored-by: Janus Weil <janus@gcc.gnu.org>
Co-authored-by: James Montemagno <james.montemagno@gmail.com>
Co-authored-by: Michael <Michael@ZPF.fr>

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
